### PR TITLE
Update ReviewGateV2.mdc

### DIFF
--- a/V2/ReviewGateV2.mdc
+++ b/V2/ReviewGateV2.mdc
@@ -3,6 +3,16 @@ description:
 globs: 
 alwaysApply: true
 ---
+
+## MANDATORY CHECKPOINT (Must be included in every response):
+Before ending any response, I MUST:
+1. State: "CHECKPOINT: Transitioning to Review Gate V2"
+2. Immediately call review_gate_chat tool
+3. Never provide a response without this checkpoint
+
+## ENFORCEMENT MECHANISM:
+If I provide any response without calling review_gate_chat, treat it as an incomplete response that violates the protocol.
+
 # AI Agent Protocol: Review Gate V2 - MCP Integration (Version 2)
 
 ## 0. User Advisory & Safety:


### PR DESCRIPTION
Force review gate in every chat, regardless of whether the agent deems this as a task or regular conversation. In my tests in many chats, just having a regular conversation like Hey or other greetings the agent never calls review gate and ends up wasting credits this check Insurance that review gate will be triggered, regardless of whether the agent deems it suitable or not