### PR TITLE
fix(mcp): prevent SSLKEYLOGFILE permission crash on startup

### DIFF
--- a/V2/INSTALLATION.md
+++ b/V2/INSTALLATION.md
@@ -179,7 +179,8 @@ Add or update this configuration block (replace paths with your actual paths):
       "env": {
         "PYTHONPATH": "/Users/YOUR_USERNAME/cursor-extensions/review-gate-v2",
         "PYTHONUNBUFFERED": "1",
-        "REVIEW_GATE_MODE": "cursor_integration"
+        "REVIEW_GATE_MODE": "cursor_integration",
+        "SSLKEYLOGFILE": ""
       }
     }
   }
@@ -200,7 +201,8 @@ Add or update this configuration block (replace paths with your actual paths):
       "env": {
         "PYTHONPATH": "C:\\Users\\YOUR_USERNAME\\cursor-extensions\\review-gate-v2",
         "PYTHONUNBUFFERED": "1",
-        "REVIEW_GATE_MODE": "cursor_integration"
+        "REVIEW_GATE_MODE": "cursor_integration",
+        "SSLKEYLOGFILE": ""
       }
     }
   }
@@ -270,6 +272,19 @@ Look for the status indicator in the popup:
 - Orange dot: MCP server is inactive
 
 ## Troubleshooting
+
+### MCP Server Crashes on Start (SSLKEYLOGFILE / Permission denied)
+
+If Cursor logs show `PermissionError` on a `Volume{...}\virtual_file.log` path while loading `faster_whisper` or `urllib3`, a global `SSLKEYLOGFILE` environment variable (often from TLS debugging tools) is blocking the MCP Python process.
+
+1. Remove the user/system variable in Windows Environment Variables, or run:
+
+```powershell
+[Environment]::SetEnvironmentVariable('SSLKEYLOGFILE', $null, 'User')
+```
+
+2. Ensure `review-gate-v2` in `%USERPROFILE%\.cursor\mcp.json` includes `"SSLKEYLOGFILE": ""` in `env` (see Step 5).
+3. Restart Cursor completely.
 
 ### MCP Server Not Starting
 

--- a/V2/mcp.json
+++ b/V2/mcp.json
@@ -6,7 +6,8 @@
       "env": {
         "PYTHONPATH": "/Users/YOUR_USERNAME/cursor-extensions/review-gate-v2",
         "PYTHONUNBUFFERED": "1",
-        "REVIEW_GATE_MODE": "cursor_integration"
+        "REVIEW_GATE_MODE": "cursor_integration",
+        "SSLKEYLOGFILE": ""
       }
     }
   }

--- a/V2/review_gate_v2_mcp.py
+++ b/V2/review_gate_v2_mcp.py
@@ -28,11 +28,14 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence
 
-# Speech-to-text imports
+# Speech-to-text imports. SSLKEYLOGFILE can make urllib3 fail at import on Windows.
+if os.environ.get("SSLKEYLOGFILE"):
+    os.environ.pop("SSLKEYLOGFILE", None)
+
 try:
     from faster_whisper import WhisperModel
     WHISPER_AVAILABLE = True
-except ImportError:
+except Exception:
     WHISPER_AVAILABLE = False
 
 from mcp.server import Server


### PR DESCRIPTION
## Summary

Fixes an MCP server crash on startup when a global `SSLKEYLOGFILE` environment variable points to a path the server process cannot write.

`faster_whisper` imports `requests` -> `urllib3`, and `urllib3` sets `context.keylog_filename = SSLKEYLOGFILE` at import time. When that path is not writable by the MCP child process, Python raises `PermissionError` before the server can connect, so Cursor reports `MCP error -32000: Connection closed` and the connection FSM goes to `failed`.

Changes:
- Drop `SSLKEYLOGFILE` from the process environment before importing `faster_whisper`.
- Broaden the speech-to-text import guard from `except ImportError` to `except Exception` so any import-time failure degrades gracefully (speech disabled) instead of taking down the whole MCP server.
- Default `SSLKEYLOGFILE` to `""` in the MCP config template (`V2/mcp.json`).
- Document the failure mode and fix in `V2/INSTALLATION.md` troubleshooting.

## Motivation

On Windows, TLS-debugging/inspection tooling sometimes sets `SSLKEYLOGFILE` machine- or user-wide. The MCP child process inherits it and crashes at import. Observed error:

```
PermissionError: [Errno 13] Permission denied: '\\?\Volume{...}\virtual_file.log'
  File ".../urllib3/util/ssl_.py", line 369, in create_urllib3_context
    context.keylog_filename = sslkeylogfile
```

## Test plan

- [x] Reproduced: with `SSLKEYLOGFILE` set to an unwritable path, the server failed to start (`PermissionError` in `create_urllib3_context`).
- [x] After fix: server imports cleanly (`WHISPER_AVAILABLE=True`), connects over stdio, lists tools, and the `review_gate_chat` popup completes a full trigger -> ack -> response round trip.
- [ ] Maintainer: confirm on macOS/Linux that unsetting `SSLKEYLOGFILE` for the child has no adverse effect (POSIX is unaffected; the var is simply not propagated to the MCP subprocess).
